### PR TITLE
Minor change to improve testing at home

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ client.on("ready", () => {
 
 client.on("message", (message) => {
   const lowerMessage = message.content.toLowerCase();
-  if (lowerMessage.substring(0, 4) === prefix) {
+  if (lowerMessage.split(" ")[0] === prefix) {
     var args = lowerMessage.substring(4).split(" ");
     args = args.splice(1);
     var cmd = args[0];


### PR DESCRIPTION
Make it so that you can test Fred at home without much noise. If you set `config.json -> prefix` to, say, `fred-test` then if you type `fred-test` in the chat, only _your_ local Fred will answer